### PR TITLE
API version is required param now

### DIFF
--- a/allauth/socialaccount/providers/vk/views.py
+++ b/allauth/socialaccount/providers/vk/views.py
@@ -42,6 +42,7 @@ class VKOAuth2Adapter(OAuth2Adapter):
     def complete_login(self, request, app, token, **kwargs):
         uid = kwargs['response'].get('user_id')
         params = {
+            'v': '3.0',
             'access_token': token.token,
             'fields': ','.join(USER_FIELDS),
         }


### PR DESCRIPTION
Without this patch

> KeyError: 'response'

`extra_data = resp.json()['response'][0]`
